### PR TITLE
Add offline Watchcount scraping tests

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+.PHONY: install run smoke e2e format lint
+
+install:
+	 pip install -r requirements.txt
+
+run:
+	 python scraper.py $(ARGS)
+
+format:
+	 black scraper.py tests/run.py
+
+lint:
+	 flake8 scraper.py tests/run.py
+
+smoke:
+	 python tests/run.py --pages 1 --expect 20
+
+e2e:
+	 python tests/run.py --pages 3 --expect 60 --outfile results.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
-# webstore
+# Watchcount Scraper
 
-▶️ [Roadmap](./ROADMAP.md)
+Command-line tool to fetch listing data directly from Watchcount.
+
+## Setup
+
+```bash
+make install
+```
+
+## Usage
+
+```bash
+python scraper.py --keywords "garden planter" --pages 3 --min-price 15 --site EBAY_GB --mode batch --output results.json
+```
+
+To run without network access, use the provided sample pages:
+
+```bash
+python scraper.py --keywords test --pages 3 --sample-dir sample_data --output results.json
+```
+
+Run smoke test:
+
+```bash
+make smoke
+```
+
+Run end-to-end test:
+
+```bash
+make e2e
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+aiohttp>=3.8
+beautifulsoup4>=4.12
+lxml>=5.2
+rich>=13.0
+tenacity>=8.2
+black
+flake8

--- a/sample_data/page1.html
+++ b/sample_data/page1.html
@@ -1,0 +1,101 @@
+<html><body><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item1">Item 1</a></span>
+  <span class="resultPrice">$1.00</span>
+  <span class="resultWatch">1</span>
+  <img src="image1.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item2">Item 2</a></span>
+  <span class="resultPrice">$2.00</span>
+  <span class="resultWatch">2</span>
+  <img src="image2.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item3">Item 3</a></span>
+  <span class="resultPrice">$3.00</span>
+  <span class="resultWatch">3</span>
+  <img src="image3.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item4">Item 4</a></span>
+  <span class="resultPrice">$4.00</span>
+  <span class="resultWatch">4</span>
+  <img src="image4.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item5">Item 5</a></span>
+  <span class="resultPrice">$5.00</span>
+  <span class="resultWatch">5</span>
+  <img src="image5.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item6">Item 6</a></span>
+  <span class="resultPrice">$6.00</span>
+  <span class="resultWatch">6</span>
+  <img src="image6.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item7">Item 7</a></span>
+  <span class="resultPrice">$7.00</span>
+  <span class="resultWatch">7</span>
+  <img src="image7.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item8">Item 8</a></span>
+  <span class="resultPrice">$8.00</span>
+  <span class="resultWatch">8</span>
+  <img src="image8.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item9">Item 9</a></span>
+  <span class="resultPrice">$9.00</span>
+  <span class="resultWatch">9</span>
+  <img src="image9.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item10">Item 10</a></span>
+  <span class="resultPrice">$10.00</span>
+  <span class="resultWatch">10</span>
+  <img src="image10.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item11">Item 11</a></span>
+  <span class="resultPrice">$11.00</span>
+  <span class="resultWatch">11</span>
+  <img src="image11.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item12">Item 12</a></span>
+  <span class="resultPrice">$12.00</span>
+  <span class="resultWatch">12</span>
+  <img src="image12.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item13">Item 13</a></span>
+  <span class="resultPrice">$13.00</span>
+  <span class="resultWatch">13</span>
+  <img src="image13.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item14">Item 14</a></span>
+  <span class="resultPrice">$14.00</span>
+  <span class="resultWatch">14</span>
+  <img src="image14.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item15">Item 15</a></span>
+  <span class="resultPrice">$15.00</span>
+  <span class="resultWatch">15</span>
+  <img src="image15.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item16">Item 16</a></span>
+  <span class="resultPrice">$16.00</span>
+  <span class="resultWatch">16</span>
+  <img src="image16.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item17">Item 17</a></span>
+  <span class="resultPrice">$17.00</span>
+  <span class="resultWatch">17</span>
+  <img src="image17.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item18">Item 18</a></span>
+  <span class="resultPrice">$18.00</span>
+  <span class="resultWatch">18</span>
+  <img src="image18.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item19">Item 19</a></span>
+  <span class="resultPrice">$19.00</span>
+  <span class="resultWatch">19</span>
+  <img src="image19.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item20">Item 20</a></span>
+  <span class="resultPrice">$20.00</span>
+  <span class="resultWatch">20</span>
+  <img src="image20.jpg"/>
+</div></body></html>

--- a/sample_data/page2.html
+++ b/sample_data/page2.html
@@ -1,0 +1,101 @@
+<html><body><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item21">Item 21</a></span>
+  <span class="resultPrice">$21.00</span>
+  <span class="resultWatch">21</span>
+  <img src="image21.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item22">Item 22</a></span>
+  <span class="resultPrice">$22.00</span>
+  <span class="resultWatch">22</span>
+  <img src="image22.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item23">Item 23</a></span>
+  <span class="resultPrice">$23.00</span>
+  <span class="resultWatch">23</span>
+  <img src="image23.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item24">Item 24</a></span>
+  <span class="resultPrice">$24.00</span>
+  <span class="resultWatch">24</span>
+  <img src="image24.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item25">Item 25</a></span>
+  <span class="resultPrice">$25.00</span>
+  <span class="resultWatch">25</span>
+  <img src="image25.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item26">Item 26</a></span>
+  <span class="resultPrice">$26.00</span>
+  <span class="resultWatch">26</span>
+  <img src="image26.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item27">Item 27</a></span>
+  <span class="resultPrice">$27.00</span>
+  <span class="resultWatch">27</span>
+  <img src="image27.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item28">Item 28</a></span>
+  <span class="resultPrice">$28.00</span>
+  <span class="resultWatch">28</span>
+  <img src="image28.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item29">Item 29</a></span>
+  <span class="resultPrice">$29.00</span>
+  <span class="resultWatch">29</span>
+  <img src="image29.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item30">Item 30</a></span>
+  <span class="resultPrice">$30.00</span>
+  <span class="resultWatch">30</span>
+  <img src="image30.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item31">Item 31</a></span>
+  <span class="resultPrice">$31.00</span>
+  <span class="resultWatch">31</span>
+  <img src="image31.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item32">Item 32</a></span>
+  <span class="resultPrice">$32.00</span>
+  <span class="resultWatch">32</span>
+  <img src="image32.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item33">Item 33</a></span>
+  <span class="resultPrice">$33.00</span>
+  <span class="resultWatch">33</span>
+  <img src="image33.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item34">Item 34</a></span>
+  <span class="resultPrice">$34.00</span>
+  <span class="resultWatch">34</span>
+  <img src="image34.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item35">Item 35</a></span>
+  <span class="resultPrice">$35.00</span>
+  <span class="resultWatch">35</span>
+  <img src="image35.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item36">Item 36</a></span>
+  <span class="resultPrice">$36.00</span>
+  <span class="resultWatch">36</span>
+  <img src="image36.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item37">Item 37</a></span>
+  <span class="resultPrice">$37.00</span>
+  <span class="resultWatch">37</span>
+  <img src="image37.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item38">Item 38</a></span>
+  <span class="resultPrice">$38.00</span>
+  <span class="resultWatch">38</span>
+  <img src="image38.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item39">Item 39</a></span>
+  <span class="resultPrice">$39.00</span>
+  <span class="resultWatch">39</span>
+  <img src="image39.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item40">Item 40</a></span>
+  <span class="resultPrice">$40.00</span>
+  <span class="resultWatch">40</span>
+  <img src="image40.jpg"/>
+</div></body></html>

--- a/sample_data/page3.html
+++ b/sample_data/page3.html
@@ -1,0 +1,101 @@
+<html><body><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item41">Item 41</a></span>
+  <span class="resultPrice">$41.00</span>
+  <span class="resultWatch">41</span>
+  <img src="image41.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item42">Item 42</a></span>
+  <span class="resultPrice">$42.00</span>
+  <span class="resultWatch">42</span>
+  <img src="image42.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item43">Item 43</a></span>
+  <span class="resultPrice">$43.00</span>
+  <span class="resultWatch">43</span>
+  <img src="image43.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item44">Item 44</a></span>
+  <span class="resultPrice">$44.00</span>
+  <span class="resultWatch">44</span>
+  <img src="image44.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item45">Item 45</a></span>
+  <span class="resultPrice">$45.00</span>
+  <span class="resultWatch">45</span>
+  <img src="image45.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item46">Item 46</a></span>
+  <span class="resultPrice">$46.00</span>
+  <span class="resultWatch">46</span>
+  <img src="image46.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item47">Item 47</a></span>
+  <span class="resultPrice">$47.00</span>
+  <span class="resultWatch">47</span>
+  <img src="image47.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item48">Item 48</a></span>
+  <span class="resultPrice">$48.00</span>
+  <span class="resultWatch">48</span>
+  <img src="image48.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item49">Item 49</a></span>
+  <span class="resultPrice">$49.00</span>
+  <span class="resultWatch">49</span>
+  <img src="image49.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item50">Item 50</a></span>
+  <span class="resultPrice">$50.00</span>
+  <span class="resultWatch">50</span>
+  <img src="image50.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item51">Item 51</a></span>
+  <span class="resultPrice">$51.00</span>
+  <span class="resultWatch">51</span>
+  <img src="image51.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item52">Item 52</a></span>
+  <span class="resultPrice">$52.00</span>
+  <span class="resultWatch">52</span>
+  <img src="image52.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item53">Item 53</a></span>
+  <span class="resultPrice">$53.00</span>
+  <span class="resultWatch">53</span>
+  <img src="image53.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item54">Item 54</a></span>
+  <span class="resultPrice">$54.00</span>
+  <span class="resultWatch">54</span>
+  <img src="image54.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item55">Item 55</a></span>
+  <span class="resultPrice">$55.00</span>
+  <span class="resultWatch">55</span>
+  <img src="image55.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item56">Item 56</a></span>
+  <span class="resultPrice">$56.00</span>
+  <span class="resultWatch">56</span>
+  <img src="image56.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item57">Item 57</a></span>
+  <span class="resultPrice">$57.00</span>
+  <span class="resultWatch">57</span>
+  <img src="image57.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item58">Item 58</a></span>
+  <span class="resultPrice">$58.00</span>
+  <span class="resultWatch">58</span>
+  <img src="image58.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item59">Item 59</a></span>
+  <span class="resultPrice">$59.00</span>
+  <span class="resultWatch">59</span>
+  <img src="image59.jpg"/>
+</div><div class="resultRow">
+  <span class="resultTitle"><a href="https://example.com/item60">Item 60</a></span>
+  <span class="resultPrice">$60.00</span>
+  <span class="resultWatch">60</span>
+  <img src="image60.jpg"/>
+</div></body></html>

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Watchcount scraper that fetches pages directly."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+from pathlib import Path
+
+import aiohttp
+from bs4 import BeautifulSoup
+from urllib.parse import quote_plus
+from rich.console import Console
+from rich.progress import Progress
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+console = Console()
+
+
+@dataclass
+class Listing:
+    id: str
+    title: str
+    url: str
+    price: str
+    watch_count: str
+    image_url: str
+
+
+class WatchcountFetcher:
+    def __init__(self, mode: str) -> None:
+        self.mode = mode
+        self.session: Optional[aiohttp.ClientSession] = None
+        self.rate_semaphore = asyncio.Semaphore(3)
+
+    async def __aenter__(self) -> "WatchcountFetcher":
+        headers = {"User-Agent": "Mozilla/5.0"}
+        self.session = aiohttp.ClientSession(headers=headers)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self.session:
+            await self.session.close()
+
+    @retry(
+        retry=retry_if_exception_type(RuntimeError),
+        wait=wait_exponential(multiplier=1, min=1, max=60),
+        stop=stop_after_attempt(5),
+    )
+    async def fetch(self, url: str) -> str:
+        assert self.session
+        if self.mode == "crawl":
+            await self.rate_semaphore.acquire()
+        try:
+            async with self.session.get(url) as resp:
+                await self._handle_rate_limit(resp)
+                return await resp.text()
+        finally:
+            if self.mode == "crawl":
+                asyncio.get_event_loop().call_later(60, self.rate_semaphore.release)
+
+    async def _handle_rate_limit(self, resp: aiohttp.ClientResponse) -> None:
+        if resp.status == 429:
+            retry_after = int(resp.headers.get("Retry-After", "60"))
+            console.log(f"Rate limited. Sleeping for {retry_after}s")
+            await asyncio.sleep(retry_after)
+            raise RuntimeError("Rate limited")
+        resp.raise_for_status()
+
+
+def parse_listings(html: str) -> List[Listing]:
+    soup = BeautifulSoup(html, "lxml")
+    listings: List[Listing] = []
+    for row in soup.select(".resultRow"):
+        title_tag = row.select_one(".resultTitle a")
+        price_tag = row.select_one(".resultPrice")
+        watch_tag = row.select_one(".resultWatch")
+        img_tag = row.select_one("img")
+        if not title_tag or not price_tag or not img_tag:
+            continue
+        url = title_tag.get("href", "")
+        item_id = url.split("/")[-1].split("?")[0]
+        listings.append(
+            Listing(
+                id=item_id,
+                title=title_tag.get_text(strip=True),
+                url=url,
+                price=price_tag.get_text(strip=True),
+                watch_count=watch_tag.get_text(strip=True) if watch_tag else "",
+                image_url=img_tag.get("src", ""),
+            )
+        )
+    return listings
+
+
+async def scrape(args: argparse.Namespace) -> List[Listing]:
+    listings: Dict[str, Listing] = {}
+
+    if args.sample_dir:
+        for i in range(args.pages):
+            path = Path(args.sample_dir) / f"page{i+1}.html"
+            html = path.read_text(encoding="utf-8")
+            for listing in parse_listings(html):
+                listings[listing.id] = listing
+        return list(listings.values())
+
+    urls = []
+    for i in range(args.pages):
+        offset = i * 20
+        keywords = quote_plus(args.keywords)
+        url = (
+            f"https://www.watchcount.com/live/{keywords}/-/all?minPrice={args.min_price}"
+            f"&offset={offset}&site={args.site}"
+        )
+        urls.append(url)
+
+    async with WatchcountFetcher(args.mode) as fetcher:
+        if args.mode == "batch":
+            html_list = await asyncio.gather(*(fetcher.fetch(u) for u in urls))
+            for html in html_list:
+                for listing in parse_listings(html):
+                    listings[listing.id] = listing
+        else:
+            for url in urls:
+                html = await fetcher.fetch(url)
+                for listing in parse_listings(html):
+                    listings[listing.id] = listing
+
+    return list(listings.values())
+
+
+def write_output(listings: List[Listing], path: Optional[str]) -> None:
+    data = [listing.__dict__ for listing in listings]
+    if path:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    else:
+        console.print_json(json.dumps(data, indent=2))
+
+
+async def main() -> int:
+    parser = argparse.ArgumentParser(description="Watchcount scraper")
+    parser.add_argument("--keywords", required=True)
+    parser.add_argument("--min-price", type=float, default=15)
+    parser.add_argument("--site", default="EBAY_GB")
+    parser.add_argument("--pages", type=int, default=5)
+    parser.add_argument("--mode", choices=["batch", "crawl"], default="batch")
+    parser.add_argument("--output", type=str)
+    parser.add_argument("--sample-dir", type=str)
+    args = parser.parse_args()
+
+    try:
+        with Progress() as progress:
+            task = progress.add_task("scraping", total=args.pages)
+            listings = await scrape(args)
+            progress.update(task, completed=args.pages)
+    except (aiohttp.ClientError, RuntimeError) as e:
+        console.print(f"Error: {e}", style="red")
+        return 1
+
+    write_output(listings, args.output)
+    console.print(f"Fetched {len(listings)} listings")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+extend-ignore = E203

--- a/tests/run.py
+++ b/tests/run.py
@@ -1,0 +1,41 @@
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pages", type=int, required=True)
+    parser.add_argument("--expect", type=int, default=0)
+    parser.add_argument("--outfile", type=Path, default=Path("/tmp/results.json"))
+    args = parser.parse_args()
+
+    cmd = [
+        sys.executable,
+        "scraper.py",
+        "--keywords",
+        "test",
+        "--pages",
+        str(args.pages),
+        "--mode",
+        "batch",
+        "--output",
+        str(args.outfile),
+        "--sample-dir",
+        "sample_data",
+    ]
+
+    subprocess.check_call(cmd)
+
+    data = json.loads(Path(args.outfile).read_text())
+    if len(data) < args.expect:
+        print(f"Expected >= {args.expect} items, got {len(data)}")
+        return 1
+    print(f"Fetched {len(data)} items")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add sample HTML pages for offline testing
- support `--sample-dir` option in scraper
- create simple test runner and update Makefile
- document offline usage in README

## Testing
- `make format`
- `make lint`
- `make smoke`
- `make e2e`


------
https://chatgpt.com/codex/tasks/task_e_686a5985350c8328a530b2edd3da407a